### PR TITLE
Rename `bom` -> `platform`

### DIFF
--- a/bom/README.md
+++ b/bom/README.md
@@ -1,4 +1,0 @@
-# Micronaut BOM
-
-This module produces the Micronaut Bill of Materials (BOM). New Entries can be added in the root `build.gradle`.
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 projectVersion=4.0.0-SNAPSHOT
-projectGroup=io.micronaut.bom
+projectGroup=io.micronaut.platform
 
-title=Micronaut BOM
+title=Micronaut Platform
 projectDesc=Bill-Of-Materials (BOM) and Gradle version catalogs for Micronaut
 projectUrl=https://micronaut.io
-githubSlug=micronaut-projects/micronaut-bom
+githubSlug=micronaut-projects/micronaut-platform
 developers=Cedric Champeau
 
 # Micronaut core branch for BOM pull requests

--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -7,8 +7,8 @@
     <version>%%version%%</version>
     <packaging>pom</packaging>
     <parent>
-        <groupId>io.micronaut.bom</groupId>
-        <artifactId>micronaut-bom</artifactId>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-platform</artifactId>
         <version>%%version%%</version>
     </parent>
     <name>Micronaut</name>

--- a/platform/README.md
+++ b/platform/README.md
@@ -1,0 +1,5 @@
+# Micronaut Platform BOM
+
+This module produces the Micronaut Bill of Materials (Platform BOM), which aggregates other Micronaut BOMs as well as recommended third-party dependencies.
+
+New Entries can be added in the `gradle/libs.versions.toml` file.

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 micronautBom {
-    propertyName.set("bom")
+    propertyName.set("platform")
     extraExcludedProjects.add("parent")
     suppressions {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,9 +9,9 @@ plugins {
     id 'io.micronaut.build.shared.settings' version '6.1.0'
 }
 
-rootProject.name = 'project-bom-parent'
+rootProject.name = 'project-platform-parent'
 
-include 'bom'
+include 'platform'
 include 'parent'
 
 micronautBuild {


### PR DESCRIPTION
The name "bom" was confusing with regards to the old BOM and the new "core" BOM. We will now refer to the BOM which aggregates several Micronaut modules (including core), driving releases, as the "platform BOM".

Each module should have its own BOM, included in this project, and this is where the "core BOM" is included.

This will require both updates to the Micronaut Build plugins and Micronaut Gradle plugin.

The repository should also be renamed for clarity.
